### PR TITLE
 Add the boolean uselocalcertificate in the firmware upgrade section of UI 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -179,6 +179,7 @@
     "firmware_upgrade_success": "Successfully started device upgrade!",
     "image_date": "Image Date",
     "keep_redirector": "Keep Redirector?",
+    "use_local_certificate": "Use Local Certificate",
     "other": "Commands",
     "override_dfs": "Override DFS",
     "reboot": "Reboot",

--- a/src/components/Modals/FirmwareUpgradeModal/index.tsx
+++ b/src/components/Modals/FirmwareUpgradeModal/index.tsx
@@ -42,6 +42,7 @@ export const FirmwareUpgradeModal = ({ modalProps: { isOpen, onClose }, serialNu
     | undefined
   >();
   const [isRedirector, { toggle }] = useBoolean(false);
+  const [useLocalCertificate, { toggle: toggleLocalCert }] = useBoolean(false);
   const { data: device, isFetching: isFetchingDevice } = useGetDevice({ serialNumber, onClose });
   const { data: firmware, isFetching: isFetchingFirmware } = useGetAvailableFirmware({
     deviceType: device?.compatible ?? '',
@@ -55,9 +56,10 @@ export const FirmwareUpgradeModal = ({ modalProps: { isOpen, onClose }, serialNu
     onModalClose: onClose,
   });
 
-  const submit = (uri: string) => {
+  const submit = (uri: string) => {useLocalCertificate
     upgrade({
       keepRedirector: isRedirector,
+      useLocalCertificate,
       uri,
       signature:
         device?.restrictedDevice && !device?.restrictionDetails?.developer ? ref.current?.values?.signature : undefined,
@@ -98,6 +100,14 @@ export const FirmwareUpgradeModal = ({ modalProps: { isOpen, onClose }, serialNu
                 </FormLabel>
                 <Switch isChecked={isRedirector} onChange={toggle} borderRadius="15px" size="lg" />
               </FormControl>
+              {/* Render a form control for "Use Local Certificate" option in Firmware Upgrade modal */}
+              <FormControl mt={3}>
+                <FormLabel ms="4px" fontSize="md" fontWeight="normal">
+                  {t('commands.use_local_certificate')}
+                </FormLabel>
+                <Switch isChecked={useLocalCertificate} onChange={toggleLocalCert} borderRadius="15px" size="lg" />
+              </FormControl>
+
               {device?.restrictedDevice && !device?.restrictionDetails?.developer && (
                 <Formik<{ signature?: string }>
                   innerRef={ref as Ref<FormikProps<{ signature?: string | undefined }>> | undefined}


### PR DESCRIPTION
Add 'Use Local Certificate' option in Firmware Upgrade modal and update translations"

Changes :-
- Added new toggle for 'Use Local Certificate' in Firmware Upgrade modal
- Updated translations in en/translation.json (Changes in translation.json were needed to add the new label key (uselocalcertificate) so the UI can display it properly instead of showing the raw key)

