### PR TITLE
Enable WifiAnalysisCard for OLG devices

### DIFF
--- a/src/pages/Device/Wrapper.tsx
+++ b/src/pages/Device/Wrapper.tsx
@@ -335,7 +335,7 @@ const DevicePageWrapper = ({ serialNumber }: Props) => {
           <DeviceSummary isCompact={isCompact} serialNumber={serialNumber} />
           <DeviceDetails serialNumber={serialNumber} />
           <DeviceStatisticsCard serialNumber={serialNumber} />
-          {getDevice.data?.deviceType === 'ap' ? <WifiAnalysisCard serialNumber={serialNumber} /> : null}
+          {getDevice.data?.deviceType === 'ap' || getDevice.data?.deviceType === 'olg' ? (  <WifiAnalysisCard serialNumber={serialNumber} /> ) : null}
           {getDevice.data?.deviceType === 'switch' ? <SwitchPortExamination serialNumber={serialNumber} /> : null}
           <DeviceLogsCard serialNumber={serialNumber} />
           {getDevice.data && getDevice.data?.hasRADIUSSessions > 0 ? (


### PR DESCRIPTION
Issue: https://github.com/routerarchitects/ra-wlan-cloud-ucentralgw-ui/issues/24

Fix:
- Update DevicePageWrapper to render the WifiAnalysisCard when deviceType is 'olg'